### PR TITLE
Ensure assets directory exists before generating image

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -45,7 +45,9 @@ jobs:
         run: go install github.com/charmbracelet/freeze@latest
 
       - name: Generate Profile Image
-        run: make image
+        run: |
+          mkdir -p assets
+          make image
 
       - name: Commit and push changes
         run: |


### PR DESCRIPTION
This PR ensures the assets directory exists before generating the profile image.

Changes:
- Added `mkdir -p assets` command before running `make image` to ensure the directory exists

This should fix the workflow failure where the assets directory might not exist in a fresh checkout.