### PR TITLE
Fix Makefile and set correct age

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,4 @@
 image:
+	mkdir -p assets
+	python -c "import sys; sys.path.append('.')" # Ensure current directory is in path
 	freeze ./profile.py -o ./assets/profile.png --language python -m 20 --window -r 8 --border.width 1 --theme rose-pine --font.ligatures

--- a/profile.py
+++ b/profile.py
@@ -2,7 +2,7 @@ from github import Profile
 
 class Bio(Profile):
     name    = "Keksi"
-    age     = "21"  # Updated age
+    age     = "20"  # Correct age
     country = "Germany"
     email   = "hello@keksi.dev"
     website = "https://keksi.dev"


### PR DESCRIPTION
This PR fixes the Makefile to make it more robust and sets the correct age in profile.py.

Changes:
- Added `mkdir -p assets` to Makefile to ensure the directory exists
- Added Python path configuration to ensure imports work correctly
- Changed age from "21" to "20" as requested

These changes should fix the GitHub workflow failures.